### PR TITLE
Remove crazy exception handling stuff.

### DIFF
--- a/omnijson/core.py
+++ b/omnijson/core.py
@@ -44,16 +44,11 @@ def loads(s, **kwargs):
     try:
         return _engine[0](s)
 
-    except:
-        # crazy 2/3 exception hack
-        # http://www.voidspace.org.uk/python/weblog/arch_d7_2010_03_20.shtml
-
-        ExceptionClass, why = sys.exc_info()[:2]
-
-        if any([(issubclass(ExceptionClass, e)) for e in _engine[2]]):
-            raise JSONError(why)
-        else:
-            raise why
+    except _engine[2]:
+        # except_clause: 'except' [test ['as' NAME]]  # grammar for py3x
+        # except_clause: 'except' [test [('as' | ',') test]] # grammar for py2x
+        why = sys.exc_info()[1]
+        raise JSONError(why)
 
 
 def dumps(o, **kwargs):


### PR DESCRIPTION
The only thing changed from py2 to py3 is variable bindings.
We still can use `except (Err1, Err2)`, i.e. tuple of exceptions.
So there is no need to catch all eception types and iterate over
it. Just catch exception in engine's tuple and retrieve
exception value through `sys.exc_info()[2]`
