### PR TITLE
Fix mistake in sample code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,10 @@ Load some objects::
     >>> json.dumps({'yo': 'dawg'})
     '{"yo": "dawg"}'
 
-Check JSON Engine::
+Check JSON 
+::
 
-    >>> json.engine
+    >>> json.core.engine
     'ujson'
 
 Install


### PR DESCRIPTION
To wit:

``` python
>>> import omnijson as json
>>> json.engine
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'engine'
>>> json.core.engine
'ujson'
```
